### PR TITLE
stats.hpp: add new lines when printing stats

### DIFF
--- a/include/taskparts/stats.hpp
+++ b/include/taskparts/stats.hpp
@@ -266,16 +266,16 @@ public:
       outfile = std::string(env_p);
     }
     FILE* f = (outfile == "") ? stdout : fopen(outfile.c_str(), "w");
-    fprintf(f, "[");
+    fprintf(f, "[\n");
     size_t i = 0;
     for (auto s : summaries) {
       output_summary(s, f);
       if (i + 1 != summaries.size()) {
-	fprintf(f, ",");
+	fprintf(f, ",\n");
       }
       i++;
     }
-    fprintf(f, "]\n");
+    fprintf(f, "\n]\n");
     if (f != stdout) {
       fclose(f);
     }


### PR DESCRIPTION
slightly beautify the stats printing from the runtime to ease the later results parsing job

### before
```
[{"exectime": 0.580,
"usertime": 31.648,
"systime": 0.015,
"nvcsw": 56,
"nivcsw": 714,
"maxrss": 95584,
"nsignals": 0,
"nb_fibers": 218834,
"nb_steals": 72962,
"total_work_time": 2.573,
"total_idle_time": 23.032,
"total_sleep_time": 0.000,
"total_time": 32.479,
"cpufreq_khz": 2800000,
"utilization": 0.291},{"exectime": 0.620,
"usertime": 33.919,
"systime": 0.020,
"nvcsw": 116,
"nivcsw": 735,
"maxrss": 97480,
"nsignals": 0,
"nb_fibers": 219272,
"nb_steals": 73113,
"total_work_time": 2.584,
"total_idle_time": 25.704,
"total_sleep_time": 0.000,
"total_time": 34.721,
"cpufreq_khz": 2800000,
"utilization": 0.260}]
```

### after
```
[
{"exectime": 0.560,
"usertime": 30.616,
"systime": 0.015,
"nvcsw": 54,
"nivcsw": 839,
"maxrss": 46308,
"nsignals": 0,
"nb_fibers": 219614,
"nb_steals": 73218,
"total_work_time": 2.560,
"total_idle_time": 23.094,
"total_sleep_time": 0.000,
"total_time": 31.343,
"cpufreq_khz": 2800000,
"utilization": 0.263},
{"exectime": 0.602,
"usertime": 32.797,
"systime": 0.014,
"nvcsw": 72,
"nivcsw": 696,
"maxrss": 48908,
"nsignals": 0,
"nb_fibers": 218969,
"nb_steals": 73015,
"total_work_time": 2.564,
"total_idle_time": 24.808,
"total_sleep_time": 0.000,
"total_time": 33.712,
"cpufreq_khz": 2800000,
"utilization": 0.264}
]
```